### PR TITLE
Add support for EVW3200-Wifi + CLI tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ Test/
 build/
 dist/
 pyubee.egg-info/
+__pycache__
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # PyUbee CHANGELOG
 This file is used to list changes made in each version of the PyUbee.
 
+## 0.3 (unreleased)
+* Add pyubee command line interface
+* Add support for EVW3200-Wifi model
+
 ## 0.2 (January 13 2019)
 * Get list of WiFi and LAN devices instead of WiFi devices only
 * Updated README.md and CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ from pyubee import Ubee
 ubee = Ubee(
                 host='192.168.1.1',
                 username='admin',
-                password='somepassword'
+                password='somepassword',
+                model='EVW32C-0N'
             )
 
 if not ubee.session_active():
@@ -28,6 +29,30 @@ for x in devices:
     print('%s (%s)' % (x, devices[x]))
 
 ubee.logout()
+```
+
+CLI
+---
+
+A simple command line interface is available to query the router. The cli takes `host`, `username`, and `password` as mandatory arguments. The optional argument model can be used to specify the model of your routers (defaults to `EVW32C-0N`.)
+```
+$ pyubee --help
+usage: pyubee [-h] [--model MODEL] host username password
+
+pyubee
+
+positional arguments:
+  host           Host
+  username       Username
+  password       Username
+
+optional arguments:
+  -h, --help     show this help message and exit
+  --model MODEL  Model, supported models: EVW32C-0N, EVW3200-Wifi
+
+$ pyubee 192.168.1.1 admin somepassword --model EVW3200-Wifi
+AA:BB:CC:DD:EE:FF	192.168.001.010
+FF:EE:DD:CC:BB:AA	192.168.001.011
 ```
 
 Notice
@@ -70,3 +95,4 @@ Supported routers
 This library was written for and tested with:
 
 * Ubee EVW32C-0N
+* Ubee EVW3200-Wifi

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pyubee
 positional arguments:
   host           Host
   username       Username
-  password       Username
+  password       Password
 
 optional arguments:
   -h, --help     show this help message and exit

--- a/pyubee/__init__.py
+++ b/pyubee/__init__.py
@@ -1,67 +1,121 @@
 """Module to communicate with Ubee routers."""
 
-import re
-import requests
 import logging
+import re
 import sys
+
+import requests
+from requests.exceptions import RequestException
+
 
 _LOGGER = logging.getLogger(__name__)
 
-_WIFI_DEVICES_REGEX = re.compile(
-    r'<tr bgcolor=#[0-9a-fA-F]+>'
-    r'<td>([0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:'
-    r'[0-9a-fA-F]{2}:[0-9a-fA-F]{2})</td>'
-    r'<td>\d+</td><td>.+</td><td>\d+\.\d+\.\d+\.\d+</td><td>(.+)</td>'
-    r'<td>.+</td><td>\d+</td></tr>'
-)
-_LAN_DEVICES_REGEX = re.compile(
-    r'<tr bgcolor=#[0-9a-fA-F]+>'
-    r'<td>([0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:'
-    r'[0-9a-fA-F]{2}:[0-9a-fA-F]{2})</td>'
-    r'<td>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}</td>()'
-)
-_LOGIN_REGEX = re.compile(r'<title>Residential Gateway Login</title>')
+MODELS = {
+    'EVW32C-0N': {
+        'url_session_active': '/UbeeSysInfo.asp',
+        'url_login': '/goform/login',
+        'url_logout': '/logout.asp',
+        'url_connected_devices_lan': '/UbeeAdvConnectedDevicesList.asp',
+        'url_connected_devices_wifi': '/UbeeAdvConnectedDevicesList.asp',
+        'regex_login': re.compile(r'<title>Residential Gateway Login</title>'),
+        'regex_wifi_devices': re.compile(
+            r'<tr bgcolor=#[0-9a-fA-F]+>'
+            r'<td>([0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:' # mac address
+            r'[0-9a-fA-F]{2}:[0-9a-fA-F]{2})</td>'  # mac address, cont'd
+            r'<td>\d+</td>'  # age?
+            r'<td>.+</td>'  # rssi?
+            r'<td>\d+\.\d+\.\d+\.\d+</td>'  # ip address
+            r'<td>(.+)</td>'  # hostname?
+            r'<td>.+</td>'  # mode?
+            r'<td>\d+</td>'  # speed?
+            r'</tr>'
+        ),
+        'regex_lan_devices': re.compile(
+            r'<tr bgcolor=#[0-9a-fA-F]+>'
+            r'<td>([0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:'  # mac address
+            r'[0-9a-fA-F]{2}:[0-9a-fA-F]{2})</td>'  # mac address, cont'd
+            r'<td>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})</td>'  # ip address
+        ),
+    },
+    'EVW3200-Wifi': {
+        'url_session_active': '/BasicStatus.asp',
+        'url_login': '/goform/loginMR3',
+        'url_logout': '/logout.asp',
+        'url_connected_devices_lan': '/RgDhcp.asp',
+        'url_connected_devices_wifi': '/wlanAccess.asp',
+        'regex_login': re.compile(r'<title>Residential Gateway Login</title>'),
+        'regex_wifi_devices': re.compile(
+            r'<tr bgcolor=#[0-9a-fA-F]+>'
+            r'<td>([0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:' # mac address
+            r'[0-9a-fA-F]{2}:[0-9a-fA-F]{2})</td>'  # mac address, cont'd
+            r'<td>\d+</td>'  # age
+            r'<td>.+</td>'  # rssi
+            r'<td>.*</td>'  # ip address
+            r'<td>(.+)?</td>'  # hostname
+            r'<td>.+</td>'  # mode
+            r'<td>\d+</td>'  # speed
+            r'</tr>'
+        ),
+        'regex_lan_devices': re.compile(
+            r'<tr bgcolor=#[0-9a-fA-F]+>'
+            r'<td>([0-9a-fA-F]{12})</td>'  # mac address
+            r'<td>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})</td>'  # ip address
+        ),
+    },
+}
+
+SUPPORTED_MODELS = MODELS.keys()
 
 
-class Ubee(object):
+class Ubee:
     """Represents a session to a Ubee Router."""
 
-    def __init__(self, host=None, username=None, password=None):
+    def __init__(self, host=None, username=None, password=None, model='EVW32C-0N'):
         """Initialize a Ubee session."""
+
+        if model not in MODELS:
+            raise LookupError('Unknown model')
 
         self.host = host
         self.username = username
         self.password = password
+        self.model = model
+        self._model_info = MODELS[model]
+
+    @property
+    def _base_url(self):
+        return 'http://{}'.format(self.host)
 
     def session_active(self):
-        """Check if session is active.""" 
-        url = "http://{}/UbeeSysInfo.asp".format(self.host)
+        """Check if session is active."""
+        url = self._base_url + self._model_info['url_session_active']
         try:
             response = requests.get(url, timeout=4)
-        except:
-            _LOGGER.error("Connection to the router failed.")
+        except RequestException as ex:
+            _LOGGER.error("Connection to the router failed: %s", ex)
             return False
 
-        title = _LOGIN_REGEX.findall(response.text)
+        title = self._model_info['regex_login'].findall(response.text)
         if title:
+            _LOGGER.debug('found login title, session not active')
             return False
 
         return True
 
     def login(self):
         """Login to Ubee Admin interface."""
-        url = "http://{}/goform/login".format(self.host)
+        url = self._base_url + self._model_info['url_login']
         payload = {
             'loginUsername': self.username,
             'loginPassword': self.password
         }
         try:
             response = requests.post(url, data=payload, timeout=4)
-        except:
-            _LOGGER.error("Connection to the router failed.")
+        except RequestException as ex:
+            _LOGGER.error("Connection to the router failed: %s", ex)
             return False
 
-        title = _LOGIN_REGEX.findall(response.text)
+        title = self._model_info['regex_login'].findall(response.text)
         if title:
             _LOGGER.error("Logging into the router failed. "
                           "Check username and password.")
@@ -74,11 +128,11 @@ class Ubee(object):
 
     def logout(self):
         """Logout from Admin interface"""
-        url = "http://{}/logout.asp".format(self.host)
+        url = self._base_url + self._model_info['url_logout']
         try:
             response = requests.get(url, timeout=4)
-        except:
-            _LOGGER.error("Connection to the router failed.")
+        except RequestException as ex:
+            _LOGGER.error("Connection to the router failed: %s", ex)
             return False
 
         if response.status_code == 200:
@@ -88,16 +142,48 @@ class Ubee(object):
 
     def get_connected_devices(self):
         """Get list of connected devices"""
-        url = "http://{}/UbeeAdvConnectedDevicesList.asp".format(self.host)
+        lan_devices = self.get_connected_devices_lan()
+        _LOGGER.debug('LAN devices: %s', lan_devices)
+        wifi_devices = self.get_connected_devices_wifi()
+        _LOGGER.debug('WIFI devices: %s', wifi_devices)
+        devices = lan_devices.copy()
+        devices.update(wifi_devices)
+        return devices
+
+    def _format_mac_address(self, address):
+        """Format a given address to a default format."""
+        # remove all ':' and '-'
+        bare = address.upper().replace(':', '').replace('-', '')
+        return ':'.join(bare[i:i + 2] for i in range(0, 12, 2))
+
+    def get_connected_devices_lan(self):
+        """Get list of connected devices via ethernet."""
+        url = self._base_url + self._model_info['url_connected_devices_lan']
         try:
             response = requests.get(url, timeout=4)
-        except requests.exceptions.Timeout:
-            _LOGGER.error("Connection to the router failed.")
+        except RequestException as ex:
+            _LOGGER.error("Connection to the router failed: %s", ex)
             return []
 
         data = response.text
-
-        DEVICES = _WIFI_DEVICES_REGEX.findall(data) + _LAN_DEVICES_REGEX.findall(data)
+        entries = self._model_info['regex_lan_devices'].findall(data)
         return {
-            key: val for key, val in DEVICES
+            self._format_mac_address(address): ip
+            for address, ip in entries
+        }
+
+    def get_connected_devices_wifi(self):
+        """Get list of connected devices via wifi."""
+        url = self._base_url + self._model_info['url_connected_devices_wifi']
+        try:
+            response = requests.get(url, timeout=4)
+        except RequestException as ex:
+            _LOGGER.error("Connection to the router failed: %s", ex)
+            return []
+
+        data = response.text
+        entries = self._model_info['regex_wifi_devices'].findall(data)
+        return {
+            self._format_mac_address(address): hostname
+            for address, hostname in entries
         }

--- a/pyubee/__init__.py
+++ b/pyubee/__init__.py
@@ -22,12 +22,12 @@ MODELS = {
             r'<tr bgcolor=#[0-9a-fA-F]+>'
             r'<td>([0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:' # mac address
             r'[0-9a-fA-F]{2}:[0-9a-fA-F]{2})</td>'  # mac address, cont'd
-            r'<td>\d+</td>'  # age?
-            r'<td>.+</td>'  # rssi?
+            r'<td>\d+</td>'  # age
+            r'<td>.+</td>'  # rssi
             r'<td>\d+\.\d+\.\d+\.\d+</td>'  # ip address
-            r'<td>(.+)</td>'  # hostname?
-            r'<td>.+</td>'  # mode?
-            r'<td>\d+</td>'  # speed?
+            r'<td>(.+)</td>'  # hostname
+            r'<td>.+</td>'  # mode
+            r'<td>\d+</td>'  # speed
             r'</tr>'
         ),
         'regex_lan_devices': re.compile(

--- a/pyubee/__main__.py
+++ b/pyubee/__main__.py
@@ -1,10 +1,35 @@
 """Run PyUbee from the command-line."""
+import argparse
+import sys
+
+from pyubee import SUPPORTED_MODELS
 from pyubee import Ubee
+
 
 def main():
     """Scan for devices and print results."""
+    parser = argparse.ArgumentParser(description='pyubee')
+    parser.add_argument('host', help='Host')
+    parser.add_argument('username', help='Username')
+    parser.add_argument('password', help='Username')
+    parser.add_argument('--model', default="EVW32C-0N",
+                        help='Model, supported models: ' + ', '.join(SUPPORTED_MODELS))
+    args = parser.parse_args()
 
-    print("Start")
+    ubee = Ubee(host=args.host,
+                username=args.username,
+                password=args.password,
+                model=args.model)
+
+    if not ubee.session_active():
+        if not ubee.login():
+            print('Could not login')
+            sys.exit(1)
+
+    devices = ubee.get_connected_devices()
+    for device in devices:
+        print("%s\t%s" % (device, devices[device]))
+
 
 if __name__ == '__main__':
     main()

--- a/pyubee/__main__.py
+++ b/pyubee/__main__.py
@@ -11,7 +11,7 @@ def main():
     parser = argparse.ArgumentParser(description='pyubee')
     parser.add_argument('host', help='Host')
     parser.add_argument('username', help='Username')
-    parser.add_argument('password', help='Username')
+    parser.add_argument('password', help='Password')
     parser.add_argument('--model', default="EVW32C-0N",
                         help='Model, supported models: ' + ', '.join(SUPPORTED_MODELS))
     args = parser.parse_args()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyubee",
-    version="0.2",
+    version="0.3.dev0",
     author="Miroslav Zdrale",
     author_email="mzdrale@gmail.com",
     description="Simple library for getting stats from Ubee routers.",
@@ -18,4 +18,8 @@ setuptools.setup(
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: OS Independent",
     ],
+    entry_points={
+        'console_scripts': ['pyubee=pyubee.__main__:main']
+    },
+
 )


### PR DESCRIPTION
I noticed this library via the Home Assistant integration. Great work!

The library, as advertised, has been written for and tested with `Ubee EVW32C-0N`. Unfortunately, this does not work for my `Ubee EVW3200-Wifi` router/cable modem. This pull request adds support for this device.

Please do not merge yet, but do test it on your own router. This works for me, but I might have broken something for your model.