### PR TITLE
Add model aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # PyUbee CHANGELOG
 This file is used to list changes made in each version of the PyUbee.
 
+## 0.5 (March 27 2019)
+* Add model aliases ([@mzdrale](https://github.com/mzdrale) - [#7](https://github.com/mzdrale/pyubee/pull/7))
+
 ## 0.4 (March 26 2019)
 * Detect Ubee model automatically ([@mzdrale](https://github.com/mzdrale) - [#5](https://github.com/mzdrale/pyubee/pull/5))
 * Move requests GET/POST to own method ([@StevenLooman](https://github.com/StevenLooman))

--- a/pyubee/__init__.py
+++ b/pyubee/__init__.py
@@ -65,7 +65,11 @@ MODELS = {
     },
 }
 
-SUPPORTED_MODELS = MODELS.keys()
+MODEL_ALIASES = {
+    'EVW3200-Wifi': 'EVW320B'
+}
+
+SUPPORTED_MODELS = list(MODELS.keys()) + list(MODEL_ALIASES.keys())
 
 
 class Ubee:
@@ -79,6 +83,9 @@ class Ubee:
 
         if model == 'detect':
             model = self.detect_model()
+
+        if model in MODEL_ALIASES:
+            model = MODEL_ALIASES.get(model)
 
         if model not in MODELS:
             raise LookupError('Unknown model')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyubee",
-    version="0.4",
+    version="0.5",
     author="Miroslav Zdrale",
     author_email="mzdrale@gmail.com",
     description="Simple library for getting stats from Ubee routers.",


### PR DESCRIPTION
Some Ubee routers can use multiple names. For example, model `EVW3200-Wifi` is reported as `EVW320B`, so I added alias.