### PR TITLE
EVW32C-0N regex fix - match device even if hostname is empty

### DIFF
--- a/pyubee/__init__.py
+++ b/pyubee/__init__.py
@@ -112,7 +112,7 @@ MODELS = {
             r'<td>\d+</td>'  # age
             r'<td>.+</td>'  # rssi
             r'<td>\d+\.\d+\.\d+\.\d+</td>'  # ip address
-            r'<td>(.+)</td>'  # hostname
+            r'<td>(.*)</td>'  # hostname
             r'<td>.+</td>'  # mode
             r'<td>\d+</td>'  # speed
             r'</tr>'


### PR DESCRIPTION
Some devices don't have hostname set in Ubee connected devices list and they didn't get picked up by pyubee before this fix.