### PR TITLE
Added support for EVW32C-0S model

### DIFF
--- a/pyubee/__init__.py
+++ b/pyubee/__init__.py
@@ -326,7 +326,8 @@ MODELS = {
 }
 
 MODEL_ALIASES = {
-    'EVW3200-Wifi': 'EVW320B'
+    'EVW3200-Wifi': 'EVW320B',
+    'EVW32C-0S': 'EVW32C-0N',
 }
 
 SUPPORTED_MODELS = list(MODELS.keys()) + list(MODEL_ALIASES.keys())


### PR DESCRIPTION
It is same as EVW32C-0N, so I have just added it to MODEL_ALIASES.

I have EVW32C-0S model, tested it, and it is working fine.